### PR TITLE
Add custom error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@
 *.dll
 *.so
 *.dylib
-*.mod
-*.sum
 
 # Test binary, build with `go test -c`
 *.test

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.dll
 *.so
 *.dylib
+*.mod
+*.sum
 
 # Test binary, build with `go test -c`
 *.test
@@ -16,4 +18,3 @@
 .*
 !.gitignore
 /github-connector/vendor
-

--- a/github-connector/Dockerfile
+++ b/github-connector/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /app
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 
 COPY --from=builder /app/main /app
+
 ARG github_secret
 ENV GITHUB_SECRET=${github_secret}
 CMD ["./main"]

--- a/github-connector/Dockerfile
+++ b/github-connector/Dockerfile
@@ -1,10 +1,8 @@
 FROM golang:1.11.4-alpine3.8 as builder
 
-
 WORKDIR /go/src/github.com/kyma-incubator/hack-showcase/github-connector
 
 COPY . .
-
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o main ./cmd/github-connector
 RUN mkdir /app && mv ./main /app/main
@@ -15,5 +13,6 @@ WORKDIR /app
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 
 COPY --from=builder /app/main /app
-
+ARG github_secret
+ENV GITHUB_SECRET=${github_secret}
 CMD ["./main"]

--- a/github-connector/Gopkg.lock
+++ b/github-connector/Gopkg.lock
@@ -34,21 +34,6 @@
   version = "v1.0.2"
 
 [[projects]]
-  branch = "error-handling"
-  digest = "1:2f366f3eb56c1c518b55324e611e6e018d371dbd77b6714a3d6ee51be90071fd"
-  name = "github.com/kyma-incubator/hack-showcase"
-  packages = [
-    "github-connector/internal/apperrors",
-    "github-connector/internal/application_registry",
-    "github-connector/internal/githubwrappers",
-    "github-connector/internal/handlers",
-    "github-connector/internal/handlers/mocks",
-    "github-connector/internal/model",
-  ]
-  pruneopts = "UT"
-  revision = "896822e69cc7896255f549f15305d9f353b70efe"
-
-[[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
@@ -113,12 +98,6 @@
   analyzer-version = 1
   input-imports = [
     "github.com/google/go-github/github",
-    "github.com/kyma-incubator/hack-showcase/github-connector/internal/apperrors",
-    "github.com/kyma-incubator/hack-showcase/github-connector/internal/application_registry",
-    "github.com/kyma-incubator/hack-showcase/github-connector/internal/githubwrappers",
-    "github.com/kyma-incubator/hack-showcase/github-connector/internal/handlers",
-    "github.com/kyma-incubator/hack-showcase/github-connector/internal/handlers/mocks",
-    "github.com/kyma-incubator/hack-showcase/github-connector/internal/model",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/mock",

--- a/github-connector/Gopkg.lock
+++ b/github-connector/Gopkg.lock
@@ -2,59 +2,91 @@
 
 
 [[projects]]
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:1e524eb1b7ed62dd58ce234056aa9178a192e951e0848a7422afa67c604d48c6"
   name = "github.com/google/go-github"
   packages = ["github"]
+  pruneopts = "UT"
   revision = "c756c329c19dbbadba0675b42af693093c3f2c45"
   version = "v27.0.1"
 
 [[projects]]
+  digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
   name = "github.com/google/go-querystring"
   packages = ["query"]
+  pruneopts = "UT"
   revision = "44c6ddd0a2342c386950e880b658017258da92fc"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
+  pruneopts = "UT"
   revision = "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e"
   version = "v1.0.2"
 
 [[projects]]
+  branch = "error-handling"
+  digest = "1:2f366f3eb56c1c518b55324e611e6e018d371dbd77b6714a3d6ee51be90071fd"
+  name = "github.com/kyma-incubator/hack-showcase"
+  packages = [
+    "github-connector/internal/apperrors",
+    "github-connector/internal/application_registry",
+    "github-connector/internal/githubwrappers",
+    "github-connector/internal/handlers",
+    "github-connector/internal/handlers/mocks",
+    "github-connector/internal/model",
+  ]
+  pruneopts = "UT"
+  revision = "896822e69cc7896255f549f15305d9f353b70efe"
+
+[[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:04457f9f6f3ffc5fea48e71d62f2ca256637dee0a04d710288e27e05c8b41976"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = "UT"
   revision = "839c75faf7f98a33d445d181f3018b5c3409a45e"
   version = "v1.4.2"
 
 [[projects]]
+  digest = "1:ac83cf90d08b63ad5f7e020ef480d319ae890c208f8524622a2f3136e2686b02"
   name = "github.com/stretchr/objx"
   packages = ["."]
+  pruneopts = "UT"
   revision = "477a77ecc69700c7cdeb1fa9e129548e1c1c393c"
   version = "v0.1.1"
 
 [[projects]]
+  digest = "1:b762f96c1183763894e8dabbac5f8e8d5821754b6e2686a8c398a174b7a58ff5"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
     "mock",
-    "require"
+    "require",
   ]
+  pruneopts = "UT"
   revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
   version = "v1.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:50804d40964a0c59170e827824e79bbf810cc10ae57603d8facce8a1f48f9a83"
   name = "golang.org/x/crypto"
   packages = [
     "cast5",
@@ -63,19 +95,34 @@
     "openpgp/elgamal",
     "openpgp/errors",
     "openpgp/packet",
-    "openpgp/s2k"
+    "openpgp/s2k",
   ]
+  pruneopts = "UT"
   revision = "4def268fd1a49955bfb3dda92fe3db4f924f2285"
 
 [[projects]]
   branch = "master"
+  digest = "1:5632b0c4d972da51b5914f09fc5c1a8535e9d8d5d937e95ef83c423a0dd67f13"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = "UT"
   revision = "fae7ac547cb717d141c433a2a173315e216b64c4"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "89655c3919fed4281751c7b6ac2bf8544776703707440e1c02106e14c4d4f2d8"
+  input-imports = [
+    "github.com/google/go-github/github",
+    "github.com/kyma-incubator/hack-showcase/github-connector/internal/apperrors",
+    "github.com/kyma-incubator/hack-showcase/github-connector/internal/application_registry",
+    "github.com/kyma-incubator/hack-showcase/github-connector/internal/githubwrappers",
+    "github.com/kyma-incubator/hack-showcase/github-connector/internal/handlers",
+    "github.com/kyma-incubator/hack-showcase/github-connector/internal/handlers/mocks",
+    "github.com/kyma-incubator/hack-showcase/github-connector/internal/model",
+    "github.com/sirupsen/logrus",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/mock",
+    "github.com/stretchr/testify/require",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/github-connector/cmd/github-connector/main.go
+++ b/github-connector/cmd/github-connector/main.go
@@ -11,8 +11,15 @@ import (
 )
 
 func main() {
-	log.Println("server started")
-	registerservice.RegisterService()
+	log.Info("server started")
+
+	id, err := registerservice.RegisterService()
+	if err != nil {
+		log.Fatal("Fatal error: %s", err.Error())
+	}
+	log.WithFields(log.Fields{
+		"id": id,
+	}).Info("Service registered")
 
 	webhook := handlers.NewWebHookHandler(
 		githubwrappers.ReceivingEventsWrapper{},

--- a/github-connector/cmd/github-connector/main.go
+++ b/github-connector/cmd/github-connector/main.go
@@ -15,7 +15,7 @@ func main() {
 
 	id, err := registerservice.RegisterService()
 	if err != nil {
-		log.Fatal("Fatal error: %s", err.Error())
+		log.Fatal("Fatal error: ", err.Error())
 	}
 	log.WithFields(log.Fields{
 		"id": id,

--- a/github-connector/internal/apperrors/apperrors.go
+++ b/github-connector/internal/apperrors/apperrors.go
@@ -8,6 +8,7 @@ const (
 	CodeAlreadyExists            = 3
 	CodeWrongInput               = 4
 	CodeUpstreamServerCallFailed = 5
+	CodeAuthenticationFailed     = 6
 )
 
 type AppError interface {
@@ -42,6 +43,10 @@ func WrongInput(format string, a ...interface{}) AppError {
 }
 
 func UpstreamServerCallFailed(format string, a ...interface{}) AppError {
+	return errorf(CodeUpstreamServerCallFailed, format, a...)
+}
+
+func AuthenticationFailed(format string, a ...interface{}) AppError {
 	return errorf(CodeUpstreamServerCallFailed, format, a...)
 }
 

--- a/github-connector/internal/apperrors/apperrors.go
+++ b/github-connector/internal/apperrors/apperrors.go
@@ -48,11 +48,11 @@ func UpstreamServerCallFailed(format string, a ...interface{}) AppError {
 }
 
 func AuthenticationFailed(format string, a ...interface{}) AppError {
-	return errorf(CodeUpstreamServerCallFailed, format, a...)
+	return errorf(CodeAuthenticationFailed, format, a...)
 }
 
 func (ae appError) Append(additionalFormat string, a ...interface{}) AppError {
-	format := additionalFormat + ": " + ae.message
+	format := additionalFormat + ", " + ae.message
 	return errorf(ae.code, format, a...)
 }
 

--- a/github-connector/internal/apperrors/apperrors.go
+++ b/github-connector/internal/apperrors/apperrors.go
@@ -1,0 +1,59 @@
+package apperrors
+
+import "fmt"
+
+const (
+	CodeInternal                 = 1
+	CodeNotFound                 = 2
+	CodeAlreadyExists            = 3
+	CodeWrongInput               = 4
+	CodeUpstreamServerCallFailed = 5
+)
+
+type AppError interface {
+	Append(string, ...interface{}) AppError
+	Code() int
+	Error() string
+}
+
+type appError struct {
+	code    int
+	message string
+}
+
+func errorf(code int, format string, a ...interface{}) AppError {
+	return appError{code: code, message: fmt.Sprintf(format, a...)}
+}
+
+func Internal(format string, a ...interface{}) AppError {
+	return errorf(CodeInternal, format, a...)
+}
+
+func NotFound(format string, a ...interface{}) AppError {
+	return errorf(CodeNotFound, format, a...)
+}
+
+func AlreadyExists(format string, a ...interface{}) AppError {
+	return errorf(CodeAlreadyExists, format, a...)
+}
+
+func WrongInput(format string, a ...interface{}) AppError {
+	return errorf(CodeWrongInput, format, a...)
+}
+
+func UpstreamServerCallFailed(format string, a ...interface{}) AppError {
+	return errorf(CodeUpstreamServerCallFailed, format, a...)
+}
+
+func (ae appError) Append(additionalFormat string, a ...interface{}) AppError {
+	format := additionalFormat + ", " + ae.message
+	return errorf(ae.code, format, a...)
+}
+
+func (ae appError) Code() int {
+	return ae.code
+}
+
+func (ae appError) Error() string {
+	return ae.message
+}

--- a/github-connector/internal/apperrors/apperrors.go
+++ b/github-connector/internal/apperrors/apperrors.go
@@ -63,3 +63,7 @@ func (ae appError) Code() int {
 func (ae appError) Error() string {
 	return ae.message
 }
+
+func (ae appError) String() string {
+	return ae.message
+}

--- a/github-connector/internal/apperrors/apperrors.go
+++ b/github-connector/internal/apperrors/apperrors.go
@@ -26,6 +26,7 @@ func errorf(code int, format string, a ...interface{}) AppError {
 	return appError{code: code, message: fmt.Sprintf(format, a...)}
 }
 
+//Internal - used for generating
 func Internal(format string, a ...interface{}) AppError {
 	return errorf(CodeInternal, format, a...)
 }

--- a/github-connector/internal/apperrors/apperrors.go
+++ b/github-connector/internal/apperrors/apperrors.go
@@ -46,7 +46,7 @@ func UpstreamServerCallFailed(format string, a ...interface{}) AppError {
 }
 
 func (ae appError) Append(additionalFormat string, a ...interface{}) AppError {
-	format := additionalFormat + ", " + ae.message
+	format := additionalFormat + ": " + ae.message
 	return errorf(ae.code, format, a...)
 }
 

--- a/github-connector/internal/apperrors/apperrors_test.go
+++ b/github-connector/internal/apperrors/apperrors_test.go
@@ -1,0 +1,89 @@
+package apperrors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppError(t *testing.T) {
+
+	t.Run("should create error with proper code", func(t *testing.T) {
+		assert.Equal(t, CodeInternal, Internal("error").Code())
+		assert.Equal(t, CodeNotFound, NotFound("error").Code())
+		assert.Equal(t, CodeAlreadyExists, AlreadyExists("error").Code())
+		assert.Equal(t, CodeWrongInput, WrongInput("error").Code())
+		assert.Equal(t, CodeUpstreamServerCallFailed, UpstreamServerCallFailed("error").Code())
+		assert.Equal(t, CodeAuthenticationFailed, AuthenticationFailed("error").Code())
+	})
+
+	t.Run("should create error with simple message", func(t *testing.T) {
+		assert.Equal(t, "error", Internal("error").Error())
+		assert.Equal(t, "error", NotFound("error").Error())
+		assert.Equal(t, "error", AlreadyExists("error").Error())
+		assert.Equal(t, "error", WrongInput("error").Error())
+		assert.Equal(t, "error", UpstreamServerCallFailed("error").Error())
+		assert.Equal(t, "error", AuthenticationFailed("error").Error())
+	})
+
+	t.Run("should create error with formatted message", func(t *testing.T) {
+		assert.Equal(t, "code: 1, error: bug", Internal("code: %d, error: %s", 1, "bug").Error())
+		assert.Equal(t, "code: 1, error: bug", NotFound("code: %d, error: %s", 1, "bug").Error())
+		assert.Equal(t, "code: 1, error: bug", AlreadyExists("code: %d, error: %s", 1, "bug").Error())
+		assert.Equal(t, "code: 1, error: bug", WrongInput("code: %d, error: %s", 1, "bug").Error())
+		assert.Equal(t, "code: 1, error: bug", UpstreamServerCallFailed("code: %d, error: %s", 1, "bug").Error())
+		assert.Equal(t, "code: 1, error: bug", AuthenticationFailed("code: %d, error: %s", 1, "bug").Error())
+	})
+
+	t.Run("should append apperrors without changing error code", func(t *testing.T) {
+		//given
+		createdInternalErr := Internal("Some Internal apperror, %s", "Some pkg err")
+		createdNotFoundErr := NotFound("Some NotFound apperror, %s", "Some pkg err")
+		createdAlreadyExistsErr := AlreadyExists("Some AlreadyExists apperror, %s", "Some pkg err")
+		createdWrongInputErr := WrongInput("Some WrongInput apperror, %s", "Some pkg err")
+		createdUpstreamServerCallFailedErr := UpstreamServerCallFailed("Some UpstreamServerCallFailed apperror, %s", "Some pkg err")
+		createdAuthenticationFailedErr := AuthenticationFailed("Some AuthenticationFailed apperror, %s", "Some pkg err")
+
+		//when
+		appendedInternalErr := createdInternalErr.Append("Some additional message")
+		appendedNotFoundErr := createdNotFoundErr.Append("Some additional message")
+		appendedAlreadyExistsErr := createdAlreadyExistsErr.Append("Some additional message")
+		appendedWrongInputErr := createdWrongInputErr.Append("Some additional message")
+		appendedUpstreamServerCallFailedErr := createdUpstreamServerCallFailedErr.Append("Some additional message")
+		appendedAuthenticationFailedErr := createdAuthenticationFailedErr.Append("Some additional message")
+
+		//then
+		assert.Equal(t, CodeInternal, appendedInternalErr.Code())
+		assert.Equal(t, CodeNotFound, appendedNotFoundErr.Code())
+		assert.Equal(t, CodeAlreadyExists, appendedAlreadyExistsErr.Code())
+		assert.Equal(t, CodeWrongInput, appendedWrongInputErr.Code())
+		assert.Equal(t, CodeUpstreamServerCallFailed, appendedUpstreamServerCallFailedErr.Code())
+		assert.Equal(t, CodeAuthenticationFailed, appendedAuthenticationFailedErr.Code())
+	})
+
+	t.Run("should append apperrors and chain messages correctly", func(t *testing.T) {
+		//given
+		createdInternalErr := Internal("Some Internal apperror, %s", "Some pkg err")
+		createdNotFoundErr := NotFound("Some NotFound apperror, %s", "Some pkg err")
+		createdAlreadyExistsErr := AlreadyExists("Some AlreadyExists apperror, %s", "Some pkg err")
+		createdWrongInputErr := WrongInput("Some WrongInput apperror, %s", "Some pkg err")
+		createdUpstreamServerCallFailedErr := UpstreamServerCallFailed("Some UpstreamServerCallFailed apperror, %s", "Some pkg err")
+		createdAuthenticationFailedErr := AuthenticationFailed("Some AuthenticationFailed apperror, %s", "Some pkg err")
+
+		//when
+		appendedInternalErr := createdInternalErr.Append("Some additional message: %s", "error")
+		appendedNotFoundErr := createdNotFoundErr.Append("Some additional message: %s", "error")
+		appendedAlreadyExistsErr := createdAlreadyExistsErr.Append("Some additional message: %s", "error")
+		appendedWrongInputErr := createdWrongInputErr.Append("Some additional message: %s", "error")
+		appendedUpstreamServerCallFailedErr := createdUpstreamServerCallFailedErr.Append("Some additional message: %s", "error")
+		appendedAuthenticationFailedErr := createdAuthenticationFailedErr.Append("Some additional message: %s", "error")
+
+		//then
+		assert.Equal(t, "Some additional message: error, Some Internal apperror, Some pkg err", appendedInternalErr.Error())
+		assert.Equal(t, "Some additional message: error, Some NotFound apperror, Some pkg err", appendedNotFoundErr.Error())
+		assert.Equal(t, "Some additional message: error, Some AlreadyExists apperror, Some pkg err", appendedAlreadyExistsErr.Error())
+		assert.Equal(t, "Some additional message: error, Some WrongInput apperror, Some pkg err", appendedWrongInputErr.Error())
+		assert.Equal(t, "Some additional message: error, Some UpstreamServerCallFailed apperror, Some pkg err", appendedUpstreamServerCallFailedErr.Error())
+		assert.Equal(t, "Some additional message: error, Some AuthenticationFailed apperror, Some pkg err", appendedAuthenticationFailedErr.Error())
+	})
+}

--- a/github-connector/internal/application_registry/registerservice.go
+++ b/github-connector/internal/application_registry/registerservice.go
@@ -1004,6 +1004,7 @@ func RegisterService() {
 	var err error
 	for i := 0; i < 10; i++ {
 		id, err = SendRegisterRequest(jsonBody, url)
+		log.Printf(err.Error())
 		if err == nil {
 			break
 		}

--- a/github-connector/internal/application_registry/registerservice.go
+++ b/github-connector/internal/application_registry/registerservice.go
@@ -1,10 +1,11 @@
 package registerservice
 
 import (
-	"log"
 	"time"
 
+	"github.com/kyma-incubator/hack-showcase/github-connector/internal/apperrors"
 	"github.com/kyma-incubator/hack-showcase/github-connector/internal/model"
+	log "github.com/sirupsen/logrus"
 )
 
 var jsonBody = model.ServiceDetails{
@@ -998,13 +999,13 @@ var jsonBody = model.ServiceDetails{
 var url = "http://application-registry-external-api.kyma-integration.svc.cluster.local:8081/github-connector-app/v1/metadata/services"
 
 //RegisterService - register service in Kyma and get a response
-func RegisterService() {
+func RegisterService() (string, apperrors.AppError) {
 
 	var id string
 	var err error
 	for i := 0; i < 10; i++ {
 		id, err = SendRegisterRequest(jsonBody, url)
-		log.Printf(err.Error())
+		log.Warn(err.Error())
 		if err == nil {
 			break
 		}
@@ -1013,8 +1014,7 @@ func RegisterService() {
 	}
 
 	if err != nil {
-		panic(err)
+		return "", apperrors.Internal("While trying to register service: %s", err.Error())
 	}
-
-	log.Printf("Application ID: " + id)
+	return id, nil
 }

--- a/github-connector/internal/application_registry/registerservice.go
+++ b/github-connector/internal/application_registry/registerservice.go
@@ -996,7 +996,7 @@ var jsonBody = model.ServiceDetails{
 	},
 }
 
-var url = "http://application-registry-external-api.kyma-integration.svc.cluster.local:8081/github-connector-error-handling-test-app/v1/metadata/services"
+var url = "http://application-registry-external-api.kyma-integration.svc.cluster.local:8081/github-connector-app/v1/metadata/services"
 
 //RegisterService - register service in Kyma and get a response
 func RegisterService() (string, apperrors.AppError) {

--- a/github-connector/internal/application_registry/registerservice.go
+++ b/github-connector/internal/application_registry/registerservice.go
@@ -996,7 +996,7 @@ var jsonBody = model.ServiceDetails{
 	},
 }
 
-var url = "http://application-registry-external-api.kyma-integration.svc.cluster.local:8081/github-connector-app/v1/metadata/services"
+var url = "http://application-registry-external-api.kyma-integration.svc.cluster.local:8081/github-connector-error-handling-test-app/v1/metadata/services"
 
 //RegisterService - register service in Kyma and get a response
 func RegisterService() (string, apperrors.AppError) {
@@ -1005,10 +1005,10 @@ func RegisterService() (string, apperrors.AppError) {
 	var err error
 	for i := 0; i < 10; i++ {
 		id, err = SendRegisterRequest(jsonBody, url)
-		log.Warn(err.Error())
 		if err == nil {
 			break
 		}
+		log.Warn(err.Error())
 
 		time.Sleep(5 * time.Second)
 	}

--- a/github-connector/internal/application_registry/sendregisterrequest.go
+++ b/github-connector/internal/application_registry/sendregisterrequest.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/kyma-incubator/hack-showcase/github-connector/internal/apperrors"
 	"github.com/kyma-incubator/hack-showcase/github-connector/internal/model"
 )
 
@@ -29,11 +30,12 @@ type RequestConfig struct {
 }
 
 //CreateJSONRequest - create http request, add headers and return client
-func CreateJSONRequest(config RequestConfig) (*http.Request, error) {
+func CreateJSONRequest(config RequestConfig) (*http.Request, apperrors.AppError) {
 	req, err := http.NewRequest(config.Type, config.URL, config.Body)
 
+	//TEST: wrong body json
 	if err != nil {
-		return nil, err
+		return nil, apperrors.Internal("Failed to create JSON request: %s", err.Error())
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -42,14 +44,18 @@ func CreateJSONRequest(config RequestConfig) (*http.Request, error) {
 }
 
 //SendJSONRequest - create json struct and try post it into application-register's url
-func SendJSONRequest(config RegisterConfig) (*http.Response, error) {
+func SendJSONRequest(config RegisterConfig) (*http.Response, apperrors.AppError) {
 
 	resp, err := config.HTTPClient.Do(config.HTTPRequest)
 
+	//TEST: no server
 	if err != nil {
-		return nil, err
+		return nil, apperrors.UpstreamServerCallFailed("Failed to make request to '%s': %s", config.HTTPRequest.URL, err.Error())
 	}
-
+	//TEST: wrong response code
+	if resp.StatusCode != http.StatusOK {
+		return nil, apperrors.UpstreamServerCallFailed("Incorrect response code '%d' while sending JSON request from %s", resp.StatusCode, config.HTTPRequest.URL)
+	}
 	return resp, nil
 }
 
@@ -59,7 +65,7 @@ func SendRegisterRequest(JSONBody model.ServiceDetails, url string) (string, err
 	// parse json to io.Reader
 	requestByte, err := json.Marshal(JSONBody)
 	if err != nil {
-		return "", err
+		return "", apperrors.Internal("Failed to parse application registry request JSON body: %s", err.Error())
 	}
 
 	requestReader := bytes.NewReader(requestByte)
@@ -71,9 +77,9 @@ func SendRegisterRequest(JSONBody model.ServiceDetails, url string) (string, err
 		Body: requestReader,
 	}
 
-	httpRequest, err := CreateJSONRequest(requestConfig)
-	if err != nil {
-		return "", err
+	httpRequest, apperr := CreateJSONRequest(requestConfig)
+	if apperr != nil {
+		return "", apperr.Append("While preparing application registry JSON request: %s", apperr)
 	}
 
 	// create register config
@@ -83,15 +89,22 @@ func SendRegisterRequest(JSONBody model.ServiceDetails, url string) (string, err
 	}
 
 	// happy JSONRequestSend-ing!
-	httpResponse, err := SendJSONRequest(config)
+	httpResponse, apperr := SendJSONRequest(config)
 
-	if err != nil {
-		return "", err
+	if apperr != nil {
+		return "", apperr.Append("While sending application registry JSON request: %s", apperr)
 	}
 
 	bodyBytes, err := ioutil.ReadAll(httpResponse.Body)
 
+	if err != nil {
+		return "", apperrors.UpstreamServerCallFailed("Failed to read service ID from application registry JSON response: %s", err)
+	}
+
 	var jsonResponse RegisterResponse
-	json.Unmarshal(bodyBytes, &jsonResponse)
+	err = json.Unmarshal(bodyBytes, &jsonResponse)
+	if err != nil {
+		return "", apperrors.Internal("Failed while unmarshaling JSON response from application registry: %s", err)
+	}
 	return jsonResponse.ID, nil
 }

--- a/github-connector/internal/application_registry/sendregisterrequest.go
+++ b/github-connector/internal/application_registry/sendregisterrequest.go
@@ -31,9 +31,12 @@ type RequestConfig struct {
 
 //CreateJSONRequest - create http request, add headers and return client
 func CreateJSONRequest(config RequestConfig) (*http.Request, apperrors.AppError) {
+	if config.Type != "POST" {
+		return nil, apperrors.Internal("Wrong http request method")
+	}
+
 	req, err := http.NewRequest(config.Type, config.URL, config.Body)
 
-	//TEST: wrong body json
 	if err != nil {
 		return nil, apperrors.Internal("Failed to create JSON request: %s", err.Error())
 	}
@@ -48,11 +51,10 @@ func SendJSONRequest(config RegisterConfig) (*http.Response, apperrors.AppError)
 
 	resp, err := config.HTTPClient.Do(config.HTTPRequest)
 
-	//TEST: no server
 	if err != nil {
 		return nil, apperrors.UpstreamServerCallFailed("Failed to make request to '%s': %s", config.HTTPRequest.URL, err.Error())
 	}
-	//TEST: wrong response code
+
 	if resp.StatusCode != http.StatusOK {
 		return nil, apperrors.UpstreamServerCallFailed("Incorrect response code '%d' while sending JSON request from %s", resp.StatusCode, config.HTTPRequest.URL)
 	}

--- a/github-connector/internal/application_registry/sendregisterrequest.go
+++ b/github-connector/internal/application_registry/sendregisterrequest.go
@@ -79,7 +79,7 @@ func SendRegisterRequest(JSONBody model.ServiceDetails, url string) (string, err
 
 	httpRequest, apperr := CreateJSONRequest(requestConfig)
 	if apperr != nil {
-		return "", apperr.Append("While preparing application registry JSON request: %s", apperr)
+		return "", apperr.Append("While preparing application registry JSON request")
 	}
 
 	// create register config
@@ -92,7 +92,7 @@ func SendRegisterRequest(JSONBody model.ServiceDetails, url string) (string, err
 	httpResponse, apperr := SendJSONRequest(config)
 
 	if apperr != nil {
-		return "", apperr.Append("While sending application registry JSON request: %s", apperr)
+		return "", apperr.Append("While sending application registry JSON request")
 	}
 
 	bodyBytes, err := ioutil.ReadAll(httpResponse.Body)

--- a/github-connector/internal/application_registry/sendregisterrequest_test.go
+++ b/github-connector/internal/application_registry/sendregisterrequest_test.go
@@ -62,6 +62,14 @@ func TestCreateJSONRequest(t *testing.T) {
 	})
 }
 
+func StatusBadRequestResponse(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusBadRequest)
+
+	json.NewEncoder(w).Encode(RegisterResponse{
+		ID: exampleID,
+	})
+}
+
 func StatusOKResponse(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 
@@ -72,7 +80,6 @@ func StatusOKResponse(w http.ResponseWriter, r *http.Request) {
 func TestSendJSONRequest_TestDataOK(t *testing.T) {
 	t.Run("should response with StatusOK code", func(t *testing.T) {
 		// given
-
 		handler := http.HandlerFunc(StatusOKResponse)
 		server := httptest.NewServer(handler)
 		defer server.Close()
@@ -82,12 +89,34 @@ func TestSendJSONRequest_TestDataOK(t *testing.T) {
 			HTTPClient:  client,
 			HTTPRequest: req,
 		}
-		//when
+
+		// when
 		res, errSendJSON := SendJSONRequest(config)
-		//then
+
+		// then
 		assert.Equal(t, res.StatusCode, http.StatusOK)
 		assert.NoError(t, errSendJSON)
 		assert.NoError(t, errNewRequest)
+	})
+	t.Run("should return an error when server responses with code other than 200", func(t *testing.T) {
+		// given
+		handler := http.HandlerFunc(StatusBadRequestResponse)
+		server := httptest.NewServer(handler)
+		defer server.Close()
+		req, errNewRequest := http.NewRequest("POST", server.URL, nil)
+		client := server.Client()
+		config := RegisterConfig{
+			HTTPClient:  client,
+			HTTPRequest: req,
+		}
+
+		// when
+		res, err := SendJSONRequest(config)
+
+		// then
+		assert.Error(t, err)
+		assert.NoError(t, errNewRequest)
+		assert.Nil(t, res)
 	})
 }
 
@@ -113,6 +142,5 @@ func TestRegisterApp(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, exampleID, res)
-
 	})
 }

--- a/github-connector/internal/application_registry/sendregisterrequest_test.go
+++ b/github-connector/internal/application_registry/sendregisterrequest_test.go
@@ -49,6 +49,17 @@ func TestCreateJSONRequest(t *testing.T) {
 		assert.Equal(t, req.URL.String(), config.URL)
 		assert.Equal(t, req.Method, config.Type)
 	})
+	t.Run("should return an error when creating a header fails", func(t *testing.T) {
+		//given
+		config := RequestConfig{URL: ":foo"}
+
+		//when
+		resp, err := CreateJSONRequest(config)
+
+		//then
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
 }
 
 func StatusOKResponse(w http.ResponseWriter, r *http.Request) {

--- a/github-connector/internal/eventparser/eventparser.go
+++ b/github-connector/internal/eventparser/eventparser.go
@@ -2,9 +2,9 @@ package eventparser
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 	"time"
+
+	"github.com/kyma-incubator/hack-showcase/github-connector/internal/apperrors"
 )
 
 // EventParser adds proper structure to existing payload, so it can be consumed by Event-Service
@@ -23,16 +23,16 @@ type EventRequestPayload struct {
 }
 
 // GetEventRequestPayload generates structure which is mapped to JSON required by Event-Service request body
-func GetEventRequestPayload(eventType, eventTypeVersion, eventID string, data json.RawMessage) (EventRequestPayload, error) {
+func GetEventRequestPayload(eventType, eventTypeVersion, eventID string, data json.RawMessage) (EventRequestPayload, apperrors.AppError) {
 
 	if eventType == "" {
-		return EventRequestPayload{}, errors.New("eventType should not be empty")
+		return EventRequestPayload{}, apperrors.WrongInput("eventType should not be empty")
 	}
 	if eventTypeVersion == "" {
-		return EventRequestPayload{}, errors.New("eventTypeVersion should not be empty")
+		return EventRequestPayload{}, apperrors.WrongInput("eventTypeVersion should not be empty")
 	}
 	if len(data) == 0 {
-		return EventRequestPayload{}, errors.New("data should not be empty")
+		return EventRequestPayload{}, apperrors.WrongInput("data should not be empty")
 	}
 
 	res := EventRequestPayload{
@@ -47,12 +47,12 @@ func GetEventRequestPayload(eventType, eventTypeVersion, eventID string, data js
 }
 
 // GetEventRequestAsJSON returns ready-to-sent JSON request body
-func GetEventRequestAsJSON(eventRequestPayload EventRequestPayload) ([]byte, error) {
+func GetEventRequestAsJSON(eventRequestPayload EventRequestPayload) ([]byte, apperrors.AppError) {
 	r, err := json.MarshalIndent(eventRequestPayload, "", "  ")
-	if err != nil {
-		fmt.Printf("error: %s", err)
 
-		return []byte{}, err
+	if err != nil {
+
+		return []byte{}, apperrors.Internal("Can not marshall given struct: %s", err.Error())
 	}
 	return r, nil
 }

--- a/github-connector/internal/githubwrappers/github_wrappers.go
+++ b/github-connector/internal/githubwrappers/github_wrappers.go
@@ -15,13 +15,19 @@ type ReceivingEventsWrapper struct {
 //ValidatePayload is a function used for checking whether the secret provided in the request is correct
 func (wh ReceivingEventsWrapper) ValidatePayload(r *http.Request, b []byte) ([]byte, apperrors.AppError) {
 	payload, err := github.ValidatePayload(r, b)
-	return payload, apperrors.AuthenticationFailed("Authentication during GitHub payload validation failed: %s", err)
+	if err != nil {
+		return nil, apperrors.AuthenticationFailed("Authentication during GitHub payload validation failed: %s", err)
+	}
+	return payload, nil
 }
 
 //ParseWebHook parses the raw json payload into an event struct
 func (wh ReceivingEventsWrapper) ParseWebHook(s string, b []byte) (interface{}, apperrors.AppError) {
 	webhook, err := github.ParseWebHook(s, b)
-	return webhook, apperrors.Internal("Failed to parse incomming github payload into object: %s", err)
+	if err != nil {
+		return nil, apperrors.Internal("Failed to parse incomming github payload into object: %s", err)
+	}
+	return webhook, nil
 }
 
 //GetToken is a function that looks for the secret in the environment

--- a/github-connector/internal/githubwrappers/github_wrappers.go
+++ b/github-connector/internal/githubwrappers/github_wrappers.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/google/go-github/github"
+	"github.com/kyma-incubator/hack-showcase/github-connector/internal/apperrors"
 )
 
 //ReceivingEventsWrapper that bundles the github library functions into one struct with a Validator interface
@@ -17,8 +18,9 @@ func (wh ReceivingEventsWrapper) ValidatePayload(r *http.Request, b []byte) ([]b
 }
 
 //ParseWebHook parses the raw json payload into an event struct
-func (wh ReceivingEventsWrapper) ParseWebHook(s string, b []byte) (interface{}, error) {
-	return github.ParseWebHook(s, b)
+func (wh ReceivingEventsWrapper) ParseWebHook(s string, b []byte) (interface{}, apperrors.AppError) {
+	webhook, err := github.ParseWebHook(s, b)
+	return webhook, apperrors.Internal("Failed to parse incomming github payload into struct: %s", err)
 }
 
 //GetToken is a function that looks for the secret in the environment

--- a/github-connector/internal/githubwrappers/github_wrappers.go
+++ b/github-connector/internal/githubwrappers/github_wrappers.go
@@ -13,14 +13,15 @@ type ReceivingEventsWrapper struct {
 }
 
 //ValidatePayload is a function used for checking whether the secret provided in the request is correct
-func (wh ReceivingEventsWrapper) ValidatePayload(r *http.Request, b []byte) ([]byte, error) {
-	return github.ValidatePayload(r, b)
+func (wh ReceivingEventsWrapper) ValidatePayload(r *http.Request, b []byte) ([]byte, apperrors.AppError) {
+	payload, err := github.ValidatePayload(r, b)
+	return payload, apperrors.AuthenticationFailed("Authentication during GitHub payload validation failed: %s", err)
 }
 
 //ParseWebHook parses the raw json payload into an event struct
 func (wh ReceivingEventsWrapper) ParseWebHook(s string, b []byte) (interface{}, apperrors.AppError) {
 	webhook, err := github.ParseWebHook(s, b)
-	return webhook, apperrors.Internal("Failed to parse incomming github payload into struct: %s", err)
+	return webhook, apperrors.Internal("Failed to parse incomming github payload into object: %s", err)
 }
 
 //GetToken is a function that looks for the secret in the environment

--- a/github-connector/internal/githubwrappers/github_wrappers.go
+++ b/github-connector/internal/githubwrappers/github_wrappers.go
@@ -32,5 +32,5 @@ func (wh ReceivingEventsWrapper) ParseWebHook(s string, b []byte) (interface{}, 
 
 //GetToken is a function that looks for the secret in the environment
 func (wh ReceivingEventsWrapper) GetToken() string {
-	return os.Getenv("GITHUB-SECRET")
+	return os.Getenv("GITHUB_SECRET")
 }

--- a/github-connector/internal/githubwrappers/github_wrappers.go
+++ b/github-connector/internal/githubwrappers/github_wrappers.go
@@ -25,7 +25,7 @@ func (wh ReceivingEventsWrapper) ValidatePayload(r *http.Request, b []byte) ([]b
 func (wh ReceivingEventsWrapper) ParseWebHook(s string, b []byte) (interface{}, apperrors.AppError) {
 	webhook, err := github.ParseWebHook(s, b)
 	if err != nil {
-		return nil, apperrors.Internal("Failed to parse incomming github payload into object: %s", err)
+		return nil, apperrors.WrongInput("Failed to parse incomming github payload into struct: %s", err)
 	}
 	return webhook, nil
 }

--- a/github-connector/internal/handlers/mocks/Validator.go
+++ b/github-connector/internal/handlers/mocks/Validator.go
@@ -2,6 +2,8 @@
 
 package mocks
 
+import apperrors "github.com/kyma-incubator/hack-showcase/github-connector/internal/apperrors"
+
 import http "net/http"
 import mock "github.com/stretchr/testify/mock"
 
@@ -25,7 +27,7 @@ func (_m *Validator) GetToken() string {
 }
 
 // ParseWebHook provides a mock function with given fields: _a0, _a1
-func (_m *Validator) ParseWebHook(_a0 string, _a1 []byte) (interface{}, error) {
+func (_m *Validator) ParseWebHook(_a0 string, _a1 []byte) (interface{}, apperrors.AppError) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 interface{}
@@ -37,18 +39,20 @@ func (_m *Validator) ParseWebHook(_a0 string, _a1 []byte) (interface{}, error) {
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(string, []byte) error); ok {
+	var r1 apperrors.AppError
+	if rf, ok := ret.Get(1).(func(string, []byte) apperrors.AppError); ok {
 		r1 = rf(_a0, _a1)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(apperrors.AppError)
+		}
 	}
 
 	return r0, r1
 }
 
 // ValidatePayload provides a mock function with given fields: _a0, _a1
-func (_m *Validator) ValidatePayload(_a0 *http.Request, _a1 []byte) ([]byte, error) {
+func (_m *Validator) ValidatePayload(_a0 *http.Request, _a1 []byte) ([]byte, apperrors.AppError) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 []byte
@@ -60,11 +64,13 @@ func (_m *Validator) ValidatePayload(_a0 *http.Request, _a1 []byte) ([]byte, err
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(*http.Request, []byte) error); ok {
+	var r1 apperrors.AppError
+	if rf, ok := ret.Get(1).(func(*http.Request, []byte) apperrors.AppError); ok {
 		r1 = rf(_a0, _a1)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(apperrors.AppError)
+		}
 	}
 
 	return r0, r1

--- a/github-connector/internal/handlers/webhookhandler.go
+++ b/github-connector/internal/handlers/webhookhandler.go
@@ -34,7 +34,7 @@ func (wh *WebHookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) 
 	payload, apperr := wh.validator.ValidatePayload(r, []byte(wh.validator.GetToken()))
 
 	if apperr != nil {
-		apperr.Append("While handling '/webhook' endpoint")
+		apperr = apperr.Append("While handling '/webhook' endpoint")
 
 		log.Warn(apperr.Error())
 		httperrors.SendErrorResponse(apperr, w)
@@ -43,7 +43,7 @@ func (wh *WebHookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) 
 
 	event, apperr := wh.validator.ParseWebHook(github.WebHookType(r), payload)
 	if apperr != nil {
-		apperr.Append("While handling '/webhook' endpoint")
+		apperr = apperr.Append("While handling '/webhook' endpoint")
 
 		log.Warn(apperr.Error())
 		httperrors.SendErrorResponse(apperr, w)

--- a/github-connector/internal/handlers/webhookhandler.go
+++ b/github-connector/internal/handlers/webhookhandler.go
@@ -37,7 +37,7 @@ func (wh *WebHookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) 
 		apperr.Append("While handling '/webhook' endpoint")
 
 		log.Warn(apperr.Error())
-		httperrors.SendErrorResponse(&apperr, &w)
+		httperrors.SendErrorResponse(apperr, w)
 		return
 	}
 
@@ -46,7 +46,7 @@ func (wh *WebHookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) 
 		apperr.Append("While handling '/webhook' endpoint")
 
 		log.Warn(apperr.Error())
-		httperrors.SendErrorResponse(&apperr, &w)
+		httperrors.SendErrorResponse(apperr, w)
 		return
 	}
 
@@ -77,7 +77,7 @@ func (wh *WebHookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) 
 		apperr := apperrors.NotFound("Unknown event type: '%s'", github.WebHookType(r))
 
 		log.Warnf(apperr.Error())
-		httperrors.SendErrorResponse(&apperr, &w)
+		httperrors.SendErrorResponse(apperr, w)
 		return
 	}
 	w.WriteHeader(http.StatusOK)

--- a/github-connector/internal/handlers/webhookhandler.go
+++ b/github-connector/internal/handlers/webhookhandler.go
@@ -5,12 +5,13 @@ import (
 	"net/http"
 
 	"github.com/google/go-github/github"
+	"github.com/kyma-incubator/hack-showcase/github-connector/internal/apperrors"
 )
 
 //Validator is an interface used to allow mocking the github library methods
 type Validator interface {
-	ValidatePayload(*http.Request, []byte) ([]byte, error)
-	ParseWebHook(string, []byte) (interface{}, error)
+	ValidatePayload(*http.Request, []byte) ([]byte, apperrors.AppError)
+	ParseWebHook(string, []byte) (interface{}, apperrors.AppError)
 	GetToken() string
 }
 

--- a/github-connector/internal/handlers/webhookhandler.go
+++ b/github-connector/internal/handlers/webhookhandler.go
@@ -27,27 +27,9 @@ func NewWebHookHandler(v Validator) *WebHookHandler {
 	return &WebHookHandler{validator: v}
 }
 
-func IsGithubEvent(r *http.Request) bool {
-	_, headerEvent := r.Header["X-GitHub-Event"]
-	_, headerSignature := r.Header["X-Hub-Signature"]
-	_, headerDelivery := r.Header["X-GitHub-Delivery"]
-
-	if headerEvent && headerSignature && headerDelivery {
-		return true
-	}
-	return false
-}
-
-//SendErrorResposne
-
 //HandleWebhook is a function that handles the /webhook endpoint.
 func (wh *WebHookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
-
-	if IsGithubEvent(r) == false {
-		log.Warn(apperrors.WrongInput("Incomming event is not recognized as GitHub event."))
-		return
-	}
 
 	payload, apperr := wh.validator.ValidatePayload(r, []byte(wh.validator.GetToken()))
 

--- a/github-connector/internal/handlers/webhookhandler.go
+++ b/github-connector/internal/handlers/webhookhandler.go
@@ -46,6 +46,7 @@ func (wh *WebHookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) 
 
 	if IsGithubEvent(r) == false {
 		log.Warn(apperrors.WrongInput("Incomming event is not recognized as GitHub event."))
+		return
 	}
 
 	payload, apperr := wh.validator.ValidatePayload(r, []byte(wh.validator.GetToken()))

--- a/github-connector/internal/handlers/webhookhandler.go
+++ b/github-connector/internal/handlers/webhookhandler.go
@@ -1,7 +1,10 @@
 package handlers
 
 import (
+	"encoding/json"
 	"net/http"
+
+	"github.com/kyma-incubator/hack-showcase/github-connector/internal/httperrors"
 
 	"github.com/google/go-github/github"
 	"github.com/kyma-incubator/hack-showcase/github-connector/internal/apperrors"
@@ -28,50 +31,75 @@ func NewWebHookHandler(v Validator) *WebHookHandler {
 //HandleWebhook is a function that handles the /webhook endpoint.
 func (wh *WebHookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 
-	payload, appError := wh.validator.ValidatePayload(r, []byte(wh.validator.GetToken()))
+	payload, apperr := wh.validator.ValidatePayload(r, []byte(wh.validator.GetToken()))
 
-	if appError != nil {
-		log.Printf("%v", appError) //TODO
-		w.WriteHeader(http.StatusUnauthorized)
-
+	if apperr != nil {
+		apperr.Append("While handling '/webhook' endpoint")
+		log.Warn(apperr.Error())
+		httpcode, resp := httperrors.AppErrorToResponse(apperr, false)
+		w.WriteHeader(httpcode)
+		body, err := json.Marshal(resp)
+		if err != nil {
+			errjson := apperrors.Internal("Failed to marshal json response: %s", err)
+			log.Warn(errjson)
+			return
+		}
+		w.Write(body)
 		return
 	}
 	defer r.Body.Close()
 
-	event, err := wh.validator.ParseWebHook(github.WebHookType(r), payload)
-	if err != nil {
-		// log.Warn("%s", httperrors.AppErrorToResponse(appError, false)) //TODO
-		w.WriteHeader(http.StatusBadRequest)
+	event, apperr := wh.validator.ParseWebHook(github.WebHookType(r), payload)
+	if apperr != nil {
+		apperr.Append("While handling '/webhook' endpoint")
+		log.Warn(apperr.Error())
+		httpcode, resp := httperrors.AppErrorToResponse(apperr, false)
+		w.WriteHeader(httpcode)
+		body, err := json.Marshal(resp)
+		if err != nil {
+			errjson := apperrors.Internal("Failed to marshal json response: %s", err)
+			log.Warn(errjson)
+			return
+		}
+		w.Write(body)
 		return
 	}
 
 	switch e := event.(type) {
 	case *github.IssuesEvent:
-		log.Printf("%s has opened an issue: \"%s\"",
+		log.Infof("%s has opened an issue: '%s'.",
 			e.GetSender().GetLogin(), e.GetIssue().GetTitle())
 
 	case *github.PullRequestReviewEvent:
 		if e.GetAction() == "submitted" {
-			log.Printf("%s has submitted a review on pull request: \"%s\"",
+			log.Infof("%s has submitted a review on pull request: '%s'.",
 				e.GetSender().GetLogin(), e.GetPullRequest().GetTitle())
 		}
 	case *github.PushEvent:
-		log.Printf("push")
+		log.Infof("Push")
 	case *github.WatchEvent:
-		log.Printf("%s is watching repo \"%s\"\n",
+		log.Infof("%s is watching repo '%s'.",
 			e.GetSender().GetLogin(), e.GetRepo().GetFullName())
 	case *github.StarEvent:
 		if e.GetAction() == "created" {
-			log.Printf("repository starred\n")
+			log.Infof("Repository starred.")
 		} else if e.GetAction() == "deleted" {
-			log.Printf("repository unstarred\n")
+			log.Infof("Repository unstarred.")
 		}
 	case *github.PingEvent:
 
 	default:
-		log.Printf("unknown event type: \"%s\"\n", github.WebHookType(r))
-
-		w.WriteHeader(http.StatusBadRequest)
+		apperr := apperrors.NotFound("Unknown event type: '%s'", github.WebHookType(r))
+		log.Warnf(apperr.Error())
+		httpcode, resp := httperrors.AppErrorToResponse(apperr, false)
+		w.WriteHeader(httpcode)
+		body, err := json.Marshal(resp)
+		if err != nil {
+			errjson := apperrors.Internal("Failed to marshal json response: %s", err)
+			log.Warn(errjson)
+			return
+		}
+		w.Write(body)
 		return
 	}
 	w.WriteHeader(http.StatusOK)

--- a/github-connector/internal/handlers/webhookhandler.go
+++ b/github-connector/internal/handlers/webhookhandler.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/google/go-github/github"
 	"github.com/kyma-incubator/hack-showcase/github-connector/internal/apperrors"
-	"github.com/kyma-incubator/hack-showcase/github-connector/internal/httperrors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -41,14 +40,13 @@ func (wh *WebHookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) 
 
 	event, err := wh.validator.ParseWebHook(github.WebHookType(r), payload)
 	if err != nil {
-		log.Warn(httperrors.AppErrorToResponse(appError, false)) //TODO
+		// log.Warn("%s", httperrors.AppErrorToResponse(appError, false)) //TODO
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
 	switch e := event.(type) {
 	case *github.IssuesEvent:
-
 		log.Printf("%s has opened an issue: \"%s\"",
 			e.GetSender().GetLogin(), e.GetIssue().GetTitle())
 

--- a/github-connector/internal/handlers/webhookhandler_test.go
+++ b/github-connector/internal/handlers/webhookhandler_test.go
@@ -60,7 +60,6 @@ func TestWebhookHandler_TestBadSecret(t *testing.T) {
 		// then
 		mockHandler.AssertExpectations(t)
 		assert.Equal(t, http.StatusForbidden, rr.Code)
-
 	})
 }
 
@@ -117,9 +116,7 @@ func TestWebhookHandler_TestKnownEvent(t *testing.T) {
 		// then
 		mockHandler.AssertExpectations(t)
 		assert.Equal(t, http.StatusOK, rr.Code)
-
 	})
-
 }
 
 func TestWebhookHandler_TestUnknownEvent(t *testing.T) {
@@ -146,5 +143,4 @@ func TestWebhookHandler_TestUnknownEvent(t *testing.T) {
 		mockHandler.AssertExpectations(t)
 		assert.Equal(t, http.StatusNotFound, rr.Code)
 	})
-
 }

--- a/github-connector/internal/handlers/webhookhandler_test.go
+++ b/github-connector/internal/handlers/webhookhandler_test.go
@@ -35,7 +35,7 @@ func createRequest(t *testing.T) *http.Request {
 }
 
 func TestWebhookHandler_TestBadSecret(t *testing.T) {
-	t.Run("should respond with 401 status code", func(t *testing.T) {
+	t.Run("should respond with 403 status code", func(t *testing.T) {
 		// given
 
 		payload := toJSON{TestJSON: "test"}
@@ -59,7 +59,7 @@ func TestWebhookHandler_TestBadSecret(t *testing.T) {
 
 		// then
 		mockHandler.AssertExpectations(t)
-		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+		assert.Equal(t, http.StatusForbidden, rr.Code)
 
 	})
 }
@@ -77,7 +77,7 @@ func TestWebhookHandler_TestWrongPayload(t *testing.T) {
 
 		mockHandler.On("GetToken").Return("test")
 		mockHandler.On("ValidatePayload", req, []byte("test")).Return(mockPayload, nil)
-		mockHandler.On("ParseWebHook", "", mockPayload).Return(nil, apperrors.Internal("fail"))
+		mockHandler.On("ParseWebHook", "", mockPayload).Return(nil, apperrors.WrongInput("fail"))
 
 		wh := NewWebHookHandler(mockHandler)
 
@@ -144,7 +144,7 @@ func TestWebhookHandler_TestUnknownEvent(t *testing.T) {
 
 		// then
 		mockHandler.AssertExpectations(t)
-		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		assert.Equal(t, http.StatusNotFound, rr.Code)
 	})
 
 }

--- a/github-connector/internal/handlers/webhookhandler_test.go
+++ b/github-connector/internal/handlers/webhookhandler_test.go
@@ -3,16 +3,17 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/google/go-github/github"
 	"github.com/kyma-incubator/hack-showcase/github-connector/internal/handlers/mocks"
-	"github.com/stretchr/testify/require"
+
+	"github.com/kyma-incubator/hack-showcase/github-connector/internal/apperrors"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type toJSON struct {
@@ -48,7 +49,7 @@ func TestWebhookHandler_TestBadSecret(t *testing.T) {
 		mockHandler := &mocks.Validator{}
 
 		mockHandler.On("GetToken").Return("test")
-		mockHandler.On("ValidatePayload", req, []byte("test")).Return(nil, errors.New("failed"))
+		mockHandler.On("ValidatePayload", req, []byte("test")).Return(nil, apperrors.AuthenticationFailed("fail"))
 
 		// when
 		wh := NewWebHookHandler(mockHandler)
@@ -76,7 +77,7 @@ func TestWebhookHandler_TestWrongPayload(t *testing.T) {
 
 		mockHandler.On("GetToken").Return("test")
 		mockHandler.On("ValidatePayload", req, []byte("test")).Return(mockPayload, nil)
-		mockHandler.On("ParseWebHook", "", mockPayload).Return(nil, errors.New("failed"))
+		mockHandler.On("ParseWebHook", "", mockPayload).Return(nil, apperrors.Internal("fail"))
 
 		wh := NewWebHookHandler(mockHandler)
 
@@ -87,7 +88,6 @@ func TestWebhookHandler_TestWrongPayload(t *testing.T) {
 		// then
 		mockHandler.AssertExpectations(t)
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
-
 	})
 
 }

--- a/github-connector/internal/httperrors/httperrors.go
+++ b/github-connector/internal/httperrors/httperrors.go
@@ -60,7 +60,8 @@ func SendErrorResponse(apperrptr *apperrors.AppError, wptr *http.ResponseWriter)
 	respJSON, err := json.Marshal(resp)
 
 	if err != nil {
-		log.Warn(apperrors.Internal("Failed to marshal error response: %s \n\tError body: %s", err, apperr.Error()))
+		marshalerr := apperrors.Internal("Failed to marshal error response: %s \nError body: %s", err, apperr.Error())
+		log.Warn(marshalerr)
 		return
 	}
 	w.Write(respJSON)

--- a/github-connector/internal/httperrors/httperrors.go
+++ b/github-connector/internal/httperrors/httperrors.go
@@ -50,9 +50,7 @@ func isInternalError(httpCode int) bool {
 }
 
 //SendErrorResponse prepares the http error response and sends it to the client
-func SendErrorResponse(apperrptr *apperrors.AppError, wptr *http.ResponseWriter) {
-	apperr := *apperrptr
-	w := *wptr
+func SendErrorResponse(apperr apperrors.AppError, w http.ResponseWriter) {
 
 	httpcode, resp := AppErrorToResponse(apperr, false)
 

--- a/github-connector/internal/httperrors/httperrors.go
+++ b/github-connector/internal/httperrors/httperrors.go
@@ -29,6 +29,8 @@ func errorCodeToHttpStatus(code int) int {
 		return http.StatusBadRequest
 	case apperrors.CodeUpstreamServerCallFailed:
 		return http.StatusBadGateway
+	case apperrors.CodeAuthenticationFailed:
+		return http.StatusForbidden
 	default:
 		return http.StatusInternalServerError
 	}

--- a/github-connector/internal/httperrors/httperrors.go
+++ b/github-connector/internal/httperrors/httperrors.go
@@ -1,0 +1,46 @@
+package httperrors
+
+import (
+	"net/http"
+
+	"github.com/kyma-incubator/hack-showcase/github-connector/internal/apperrors"
+)
+
+type ErrorResponse struct {
+	Code  int    `json:"code"`
+	Error string `json:"error"`
+}
+
+func AppErrorToResponse(appError apperrors.AppError, detailedErrorResponse bool) (status int, body ErrorResponse) {
+	httpCode := errorCodeToHttpStatus(appError.Code())
+	errorMessage := appError.Error()
+	return formatErrorResponse(httpCode, errorMessage, detailedErrorResponse)
+}
+
+func errorCodeToHttpStatus(code int) int {
+	switch code {
+	case apperrors.CodeInternal:
+		return http.StatusInternalServerError
+	case apperrors.CodeNotFound:
+		return http.StatusNotFound
+	case apperrors.CodeAlreadyExists:
+		return http.StatusConflict
+	case apperrors.CodeWrongInput:
+		return http.StatusBadRequest
+	case apperrors.CodeUpstreamServerCallFailed:
+		return http.StatusBadGateway
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+func formatErrorResponse(httpCode int, errorMessage string, detailedErrorResponse bool) (status int, body ErrorResponse) {
+	if isInternalError(httpCode) && !detailedErrorResponse {
+		return httpCode, ErrorResponse{httpCode, "Internal error."}
+	}
+	return httpCode, ErrorResponse{httpCode, errorMessage}
+}
+
+func isInternalError(httpCode int) bool {
+	return httpCode == http.StatusInternalServerError
+}

--- a/github-connector/internal/httperrors/httperrors.go
+++ b/github-connector/internal/httperrors/httperrors.go
@@ -32,7 +32,7 @@ func errorCodeToHttpStatus(code int) int {
 	case apperrors.CodeUpstreamServerCallFailed:
 		return http.StatusBadGateway
 	case apperrors.CodeAuthenticationFailed:
-		return http.StatusForbidden
+              return http.StatusUnauthorized
 	default:
 		return http.StatusInternalServerError
 	}


### PR DESCRIPTION
The error handling structure is based on error handling found in Application Registry. Internal errors are handled using set of methods from package **```apperrors```**, while outcoming communication with client from package **```httperrors```**.
* ```sirupsen/logrus``` library is used to log errors.
* Internal AppErrors are logged only in uppermost level - ```HandleWebhook()``` and ```RegisterService()``` - so the error is passed throughout all intermediate stages wrapped in contextual error messages. 
* At the uppermost level the error is mapped into http response and sent to client.