### PR TITLE
Slack documentation

### DIFF
--- a/chart/slackconnector/README.md
+++ b/chart/slackconnector/README.md
@@ -1,0 +1,6 @@
+# Slack Connector <!-- omit in toc -->
+
+## Overview
+
+The chart creates a Slack Connector Deployment and a Namespace in Kyma.
+Moreover it creates an application and a service which is binded to the newly created namespace.

--- a/chart/slackconnector/README.md
+++ b/chart/slackconnector/README.md
@@ -3,4 +3,4 @@
 ## Overview
 
 The chart creates a Slack Connector Deployment and a Namespace in Kyma.
-Moreover it creates an application and a service which is binded to the newly created namespace.
+Moreover, it creates an application and a service which is bound to the newly created Namespace.

--- a/docs/slack-connector/README.md
+++ b/docs/slack-connector/README.md
@@ -19,6 +19,8 @@ Slack Connector is a component which allows contact from inside of Kyma environm
 ### Steps
 
 1. Visit our [authentication page](https://auth-slack.herokuapp.com/). Click `Add to Slack`. You will be redirected to another page. Select your desired workspace and click `Allow`
+    >**NOTE:** If the link doesn't work it means that you have to create an application like that yourself. The tutorial for that can be found in the Slack API [documentation](https://api.slack.com/docs/oauth#flow).
+
 2. Copy the authentication token. You will need it later in the Helm command.
 3. Go to [Kyma repository](https://github.com/kyma-project/kyma) and run script `/installation/scripts/tiller-tls.sh` to get certificates needed for using Helm commands. By default they are stored in `~/.helm` directory. After that add `--tls` flag to every Helm command to authorize and authenticate yourself
 4. Go to `chart/slackconnector` directory. Run the command to install Slack Connector:

--- a/docs/slack-connector/README.md
+++ b/docs/slack-connector/README.md
@@ -29,5 +29,5 @@ Slack Connector is a component which allows for communication between the Kyma e
     helm install --set container.image={DOCKER_IMAGE} --set kymaAddress={KYMA_ADDRESS} --set slackBotToken={SLACK_TOKEN} -n {RELEASE_NAME} . --tls
     ```
 
-    >**CAUTION:** Kyma address should be in the right format. It must consist of domain name, without dot  character at the beggining, for example `35.187.32.214.xip.io`
+    >**CAUTION:** Make sure that the Kyma address is in the correct format. It must consist of the domain name, without the dot character at the beginning. For example, `35.187.32.214.xip.io`.
     >**NOTE:** To define Namespace in which chart should be installed add flag `--namespace`.

--- a/docs/slack-connector/README.md
+++ b/docs/slack-connector/README.md
@@ -19,7 +19,7 @@ Slack Connector is a component which allows contact from inside of Kyma environm
 ### Steps
 
 1. Go to the [authentication page](https://auth-slack.herokuapp.com/). Click `Add to Slack`. This redirects you to another page. Select your desired workspace and click `Allow`.
-    >**NOTE:** If the link does not work, it means that an application that authenticates the connector in your workspace does not exist and you have to create it yourself. To create an application like that, see [this tutorial](https://api.slack.com/docs/oauth#flow) in the Slack API documentation.
+    >**NOTE:** If the link does not work, it means that an application that authenticates the connector in your workspace does not exist and you have to create it yourself. To create such an application, see [this tutorial](https://api.slack.com/docs/oauth#flow) in the Slack API documentation.
 
 2. Copy the authentication token. You will need it later in the Helm command.
 3. Go to [Kyma repository](https://github.com/kyma-project/kyma) and run the script `/installation/scripts/tiller-tls.sh` to get certificates needed for using Helm commands. By default they are stored in `~/.helm` directory. After that add `--tls` flag to every Helm command to authorize and authenticate yourself

--- a/docs/slack-connector/README.md
+++ b/docs/slack-connector/README.md
@@ -1,0 +1,31 @@
+# Slack Connector Installation<!-- omit in toc -->
+
+- [Overview](#overview)
+- [Installation in Kyma with Helm](#installation-in-kyma-with-helm)
+  - [Prerequisites](#prerequisites)
+  - [Steps](#steps)
+
+## Overview
+
+Slack Connector is a component which allows contact from inside of Kyma environment to the Slack API.
+
+## Installation in Kyma with Helm
+
+### Prerequisites
+
+- Connection to Kyma cluster
+- Slack Connector Docker image
+
+### Steps
+
+1. Visit our [authentication page](https://auth-slack.herokuapp.com/). Click `Add to Slack`. You will be redirected to another page. Select your desired workspace and click `Allow`
+2. Copy the authentication token. You will need it later in the Helm command.
+3. Go to [Kyma repository](https://github.com/kyma-project/kyma) and run script `/installation/scripts/tiller-tls.sh` to get certificates needed for using Helm commands. By default they are stored in `~/.helm` directory. After that add `--tls` flag to every Helm command to authorize and authenticate yourself
+4. Go to `chart/slackconnector` directory. Run the command to install Slack Connector:
+
+    ``` shell
+    helm install --set container.image={DOCKER_IMAGE} --set kymaAddress={KYMA_ADDRESS} --set slackBotToken={SLACK_TOKEN} -n {RELEASE_NAME} . --tls
+    ```
+
+    >**CAUTION:** Kyma address should be in the right format. It must consist of domain name, without dot  character at the beggining, for example `35.187.32.214.xip.io`
+    >**NOTE:** To define Namespace in which chart should be installed add flag `--namespace`.

--- a/docs/slack-connector/README.md
+++ b/docs/slack-connector/README.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-Slack Connector is a component which allows contact from inside of Kyma environment to the Slack API.
+The Slack Connector is a component which allows contact from inside of Kyma environment to the Slack API.
 
 ## Installation in Kyma with Helm
 
@@ -23,7 +23,7 @@ Slack Connector is a component which allows contact from inside of Kyma environm
 
 2. Copy the authentication token. You will need it later in the Helm command.
 3. Go to [Kyma repository](https://github.com/kyma-project/kyma) and run the script `/installation/scripts/tiller-tls.sh` to get certificates needed for using Helm commands. By default they are stored in `~/.helm` directory. After that add `--tls` flag to every Helm command to authorize and authenticate the user.
-4. Go to the `chart/slackconnector` directory. Run this command to install Slack Connector:
+4. Go to the `chart/slackconnector` directory. Run this command to install the Slack Connector:
 
     ``` shell
     helm install --set container.image={DOCKER_IMAGE} --set kymaAddress={KYMA_ADDRESS} --set slackBotToken={SLACK_TOKEN} -n {RELEASE_NAME} . --tls

--- a/docs/slack-connector/README.md
+++ b/docs/slack-connector/README.md
@@ -23,7 +23,7 @@ Slack Connector is a component which allows contact from inside of Kyma environm
 
 2. Copy the authentication token. You will need it later in the Helm command.
 3. Go to [Kyma repository](https://github.com/kyma-project/kyma) and run script `/installation/scripts/tiller-tls.sh` to get certificates needed for using Helm commands. By default they are stored in `~/.helm` directory. After that add `--tls` flag to every Helm command to authorize and authenticate yourself
-4. Go to `chart/slackconnector` directory. Run the command to install Slack Connector:
+4. Go to the `chart/slackconnector` directory. Run this command to install Slack Connector:
 
     ``` shell
     helm install --set container.image={DOCKER_IMAGE} --set kymaAddress={KYMA_ADDRESS} --set slackBotToken={SLACK_TOKEN} -n {RELEASE_NAME} . --tls

--- a/docs/slack-connector/README.md
+++ b/docs/slack-connector/README.md
@@ -22,7 +22,7 @@ Slack Connector is a component which allows contact from inside of Kyma environm
     >**NOTE:** If the link does not work, it means that an application that authenticates the connector in your workspace does not exist and you have to create it yourself. To create such an application, see [this tutorial](https://api.slack.com/docs/oauth#flow) in the Slack API documentation.
 
 2. Copy the authentication token. You will need it later in the Helm command.
-3. Go to [Kyma repository](https://github.com/kyma-project/kyma) and run the script `/installation/scripts/tiller-tls.sh` to get certificates needed for using Helm commands. By default they are stored in `~/.helm` directory. After that add `--tls` flag to every Helm command to authorize and authenticate yourself
+3. Go to [Kyma repository](https://github.com/kyma-project/kyma) and run the script `/installation/scripts/tiller-tls.sh` to get certificates needed for using Helm commands. By default they are stored in `~/.helm` directory. After that add `--tls` flag to every Helm command to authorize and authenticate the user.
 4. Go to the `chart/slackconnector` directory. Run this command to install Slack Connector:
 
     ``` shell

--- a/docs/slack-connector/README.md
+++ b/docs/slack-connector/README.md
@@ -19,7 +19,7 @@ Slack Connector is a component which allows for communication between the Kyma e
 ### Steps
 
 1. Go to the [authentication page](https://auth-slack.herokuapp.com/). Click `Add to Slack`. This redirects you to another page. Select your desired workspace and click `Allow`.
-    >**NOTE:** If the link doesn't work it means that you have to create an application like that yourself. The tutorial for that can be found in the Slack API [documentation](https://api.slack.com/docs/oauth#flow).
+    >**NOTE:** If the link does not work, it means that you have to create an application like that yourself. To create an application, see [this tutorial](https://api.slack.com/docs/oauth#flow) in the Slack API documentation.
 
 2. Copy the authentication token. You will need it later in the Helm command.
 3. Go to [Kyma repository](https://github.com/kyma-project/kyma) and run script `/installation/scripts/tiller-tls.sh` to get certificates needed for using Helm commands. By default they are stored in `~/.helm` directory. After that add `--tls` flag to every Helm command to authorize and authenticate yourself

--- a/docs/slack-connector/README.md
+++ b/docs/slack-connector/README.md
@@ -18,7 +18,7 @@ Slack Connector is a component which allows for communication between the Kyma e
 
 ### Steps
 
-1. Visit our [authentication page](https://auth-slack.herokuapp.com/). Click `Add to Slack`. You will be redirected to another page. Select your desired workspace and click `Allow`
+1. Go to the [authentication page](https://auth-slack.herokuapp.com/). Click `Add to Slack`. This redirects you to another page. Select your desired workspace and click `Allow`.
     >**NOTE:** If the link doesn't work it means that you have to create an application like that yourself. The tutorial for that can be found in the Slack API [documentation](https://api.slack.com/docs/oauth#flow).
 
 2. Copy the authentication token. You will need it later in the Helm command.

--- a/docs/slack-connector/README.md
+++ b/docs/slack-connector/README.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-Slack Connector is a component which allows for communication between the Kyma environment and the Slack API.
+Slack Connector is a component which allows contact from inside of Kyma environment to the Slack API.
 
 ## Installation in Kyma with Helm
 
@@ -29,5 +29,5 @@ Slack Connector is a component which allows for communication between the Kyma e
     helm install --set container.image={DOCKER_IMAGE} --set kymaAddress={KYMA_ADDRESS} --set slackBotToken={SLACK_TOKEN} -n {RELEASE_NAME} . --tls
     ```
 
-    >**CAUTION:** Make sure that the Kyma address is in the correct format. It must consist of the domain name, without the dot character at the beginning. For example, `35.187.32.214.xip.io`.
+    >**CAUTION:** Make sure that the Kyma address is in the correct format. It consists of the domain name and omits the dot at the beginning. For example, `35.187.32.214.xip.io`.
     >**NOTE:** To define Namespace in which chart should be installed add flag `--namespace`.

--- a/docs/slack-connector/README.md
+++ b/docs/slack-connector/README.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-Slack Connector is a component which allows contact from inside of Kyma environment to the Slack API.
+Slack Connector is a component which allows for communication between the Kyma environment and the Slack API.
 
 ## Installation in Kyma with Helm
 

--- a/docs/slack-connector/README.md
+++ b/docs/slack-connector/README.md
@@ -19,10 +19,10 @@ Slack Connector is a component which allows for communication between the Kyma e
 ### Steps
 
 1. Go to the [authentication page](https://auth-slack.herokuapp.com/). Click `Add to Slack`. This redirects you to another page. Select your desired workspace and click `Allow`.
-    >**NOTE:** If the link does not work, it means that you have to create an application like that yourself. To create an application, see [this tutorial](https://api.slack.com/docs/oauth#flow) in the Slack API documentation.
+    >**NOTE:** If the link does not work, it means that an application that authenticates the connector in your workspace does not exist and you have to create it yourself. To create an application like that, see [this tutorial](https://api.slack.com/docs/oauth#flow) in the Slack API documentation.
 
 2. Copy the authentication token. You will need it later in the Helm command.
-3. Go to [Kyma repository](https://github.com/kyma-project/kyma) and run script `/installation/scripts/tiller-tls.sh` to get certificates needed for using Helm commands. By default they are stored in `~/.helm` directory. After that add `--tls` flag to every Helm command to authorize and authenticate yourself
+3. Go to [Kyma repository](https://github.com/kyma-project/kyma) and run the script `/installation/scripts/tiller-tls.sh` to get certificates needed for using Helm commands. By default they are stored in `~/.helm` directory. After that add `--tls` flag to every Helm command to authorize and authenticate yourself
 4. Go to the `chart/slackconnector` directory. Run this command to install Slack Connector:
 
     ``` shell

--- a/slack-connector/README.md
+++ b/slack-connector/README.md
@@ -1,0 +1,6 @@
+# Slack Connector
+
+## Overview
+
+Slack Connector is a component which allows contact from inside of Kyma environment to the Slack API.\
+It registers an application in the Application Registry. The installation guide can be found [here](/docs/slack-connector/installation.md)

--- a/slack-connector/README.md
+++ b/slack-connector/README.md
@@ -2,5 +2,5 @@
 
 ## Overview
 
-Slack Connector is a component which allows contact from inside of Kyma environment to the Slack API.\
+TheSlack Connector is a component which allows contact from inside of Kyma environment to the Slack API.\
 It registers an application in the Application Registry. See the installation guide [here](/docs/slack-connector/README.md)

--- a/slack-connector/README.md
+++ b/slack-connector/README.md
@@ -3,4 +3,4 @@
 ## Overview
 
 Slack Connector is a component which allows contact from inside of Kyma environment to the Slack API.\
-It registers an application in the Application Registry. The installation guide can be found [here](/docs/slack-connector/installation.md)
+It registers an application in the Application Registry. The installation guide can be found [here](/docs/slack-connector/README.md)

--- a/slack-connector/README.md
+++ b/slack-connector/README.md
@@ -2,5 +2,5 @@
 
 ## Overview
 
-TheSlack Connector is a component which allows contact from inside of Kyma environment to the Slack API.\
+The Slack Connector is a component which allows contact from inside of Kyma environment to the Slack API.\
 It registers an application in the Application Registry. See the installation guide [here](/docs/slack-connector/README.md)

--- a/slack-connector/README.md
+++ b/slack-connector/README.md
@@ -3,4 +3,4 @@
 ## Overview
 
 Slack Connector is a component which allows contact from inside of Kyma environment to the Slack API.\
-It registers an application in the Application Registry. The installation guide can be found [here](/docs/slack-connector/README.md)
+It registers an application in the Application Registry. See the installation guide [here](/docs/slack-connector/README.md)


### PR DESCRIPTION
Our slack connector had no documentation so it had to be created. It includes a README and an installation guide.