### PR TITLE
Make the event handling more generic

### DIFF
--- a/chart/githubconnector/values.yaml
+++ b/chart/githubconnector/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 container:
-  image: kymaflyingseals/github-connector:0.2.4
+  image: kymaflyingseals/github-connector:0.2.5
   containerPort: 8080
   limits:
     memory: "128Mi"

--- a/chart/githubconnector/values.yaml
+++ b/chart/githubconnector/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 container:
-  image: kymaflyingseals/github-connector:0.2.3
+  image: kymaflyingseals/github-connector:0.2.4
   containerPort: 8080
   limits:
     memory: "128Mi"

--- a/chart/githubconnector/values.yaml
+++ b/chart/githubconnector/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 container:
-  image: kymaflyingseals/github-connector:0.2.6
+  image: kymaflyingseals/github-connector:0.2.7
   containerPort: 8080
   limits:
     memory: "128Mi"

--- a/chart/githubconnector/values.yaml
+++ b/chart/githubconnector/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 container:
-  image: kymaflyingseals/github-connector:0.2.5
+  image: kymaflyingseals/github-connector:0.2.6
   containerPort: 8080
   limits:
     memory: "128Mi"

--- a/github-connector/internal/handlers/webhookhandler.go
+++ b/github-connector/internal/handlers/webhookhandler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"reflect"
@@ -60,8 +61,10 @@ func (wh *WebHookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	log.Info(reflect.Indirect(reflect.ValueOf(event)).Type().Name())
-	apperr = wh.sender.SendToKyma(reflect.Indirect(reflect.ValueOf(event)).Type().Name(), "v1", "", os.Getenv("GITHUB_CONNECTOR_NAME")+"-app", payload)
+	eventType := reflect.Indirect(reflect.ValueOf(event)).Type().Name()
+	sourceID := fmt.Sprintf("%s-app", os.Getenv("GITHUB_CONNECTOR_NAME"))
+	log.Info(eventType)
+	apperr = wh.sender.SendToKyma(eventType, "v1", "", sourceID, payload)
 
 	if apperr != nil {
 		log.Info(apperrors.Internal("While handling the event: %s", apperr.Error()))

--- a/github-connector/internal/handlers/webhookhandler_test.go
+++ b/github-connector/internal/handlers/webhookhandler_test.go
@@ -133,8 +133,7 @@ func TestWebhookHandler(t *testing.T) {
 		require.NoError(t, err)
 		mockValidator.On("GetToken").Return("test")
 		mockValidator.On("ValidatePayload", req, []byte("test")).Return(mockPayload, nil)
-		mockValidator.On("ParseWebHook", "", mockPayload).Return(1, nil)
-
+		mockValidator.On("ParseWebHook", "", mockPayload).Return(nil, apperrors.NotFound("Unknown event"))
 		wh := NewWebHookHandler(mockValidator, mockSender)
 
 		// when

--- a/github-connector/internal/registration/payloadbuilder.go
+++ b/github-connector/internal/registration/payloadbuilder.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	specificationURL          = "https://raw.githubusercontent.com/colunira/github-openapi/master/githubopenAPI.json"
+	specificationURL          = "https://raw.githubusercontent.com/kyma-incubator/hack-showcase/master/github-connector/internal/registration/configs/githubopenAPI.json"
 	applicationRegistryPrefix = "http://application-registry-external-api.kyma-integration.svc.cluster.local:8081/"
 	applicationRegistrySuffix = "-app/v1/metadata/services"
 	applicationRegistryFormat = "%s%s%s"

--- a/github-connector/internal/registration/payloadbuilder_test.go
+++ b/github-connector/internal/registration/payloadbuilder_test.go
@@ -18,7 +18,7 @@ func TestBuild(t *testing.T) {
 		jsonBody := json.RawMessage(`{"json":"value"}`)
 		mockFileReader.On("Read", "githubasyncapi.json").Return(fileBody, nil)
 		builder := registration.NewPayloadBuilder(mockFileReader, "github-connector")
-		url := "https://raw.githubusercontent.com/colunira/github-openapi/master/githubopenAPI.json"
+		url := "https://raw.githubusercontent.com/kyma-incubator/hack-showcase/master/github-connector/internal/registration/configs/githubopenAPI.json"
 
 		//when
 		details, err := builder.Build()


### PR DESCRIPTION
Change the way GitHub events are sent to Kyma. Instead of a switch case statement we classify them with the reflect package.