### PR TITLE
Slack addon dev plan fix

### DIFF
--- a/addons/slackconnector-1.0.0/chart/slackconnector/templates/deployment.yaml
+++ b/addons/slackconnector-1.0.0/chart/slackconnector/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: main
-        image: {{ .Values.container.image }}
+        image: {{ .Values.image }}
         resources:
           limits:
             memory: {{ .Values.container.limits.memory }}

--- a/addons/slackconnector-1.0.0/chart/slackconnector/values.yaml
+++ b/addons/slackconnector-1.0.0/chart/slackconnector/values.yaml
@@ -1,8 +1,7 @@
 replicaCount: 1
 
+image: kymaflyingseals/slack-connector:0.2.0
 container:
-  image: kymaflyingseals/slack-connector:0.1.0
-
   containerPort: 8080
   limits:
     memory: "128Mi"


### PR DESCRIPTION
It's not possible to provide nested values in create-instance-schema. That's why we have to change field container.image to image in values.yaml. Additionally, we need to update deployment to fit to this modification.