### PR TITLE
Move GitHub secret creation to chart

### DIFF
--- a/addons/githubconnector-1.0.0/chart/githubconnector/templates/deployment.yaml
+++ b/addons/githubconnector-1.0.0/chart/githubconnector/templates/deployment.yaml
@@ -38,6 +38,8 @@ spec:
           value: {{ include "github-connector-chart.repository" . }}
         - name: GITHUB_TOKEN
           value: {{ .Values.githubToken }}
+        - name: GITHUB_SECRET
+          value: {{ randAlphaNum 14 }}
         - name: KYMA_ADDRESS
           value: {{ include "github-connector-chart.repository" . }}.{{ .Values.kymaAddress }}
 

--- a/addons/githubconnector-1.0.0/chart/githubconnector/values.yaml
+++ b/addons/githubconnector-1.0.0/chart/githubconnector/values.yaml
@@ -6,7 +6,7 @@ container:
     memory: "128Mi"
     cpu: "500m"
 
-image: kymaflyingseals/github-connector:0.3.5
+image: kymaflyingseals/github-connector:0.3.6
 
 service:
   port: 80
@@ -14,4 +14,4 @@ service:
 githubToken: sampleToken
 kymaAddress: kyma.address.com
 githubEndpoint: 
-  - repos/colunira/podejmijtest
+  - repos/example/test

--- a/addons/githubconnector-1.0.0/chart/githubconnector/values.yaml
+++ b/addons/githubconnector-1.0.0/chart/githubconnector/values.yaml
@@ -14,4 +14,4 @@ service:
 githubToken: sampleToken
 kymaAddress: kyma.address.com
 githubEndpoint: 
-  - repos/example/test
+  - repos/colunira/podejmijtest

--- a/chart/githubconnector/templates/deployment.yaml
+++ b/chart/githubconnector/templates/deployment.yaml
@@ -37,7 +37,9 @@ spec:
         - name: GITHUB_CONNECTOR_NAME
           value: {{ .Release.Name }}
         - name: GITHUB_TOKEN
-          value: {{ .Values.githubToken }}        
+          value: {{ .Values.githubToken }}
+        - name: GITHUB_SECRET
+          value: {{- randAlphaNum 14 -}}        
         - name: KYMA_ADDRESS
           value: {{ .Release.Name }}.{{ .Values.kymaAddress }}
 

--- a/chart/githubconnector/values.yaml
+++ b/chart/githubconnector/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 container:
-  image: kymaflyingseals/github-connector:0.3.2
+  image: kymaflyingseals/github-connector:0.3.6
   containerPort: 8080
   limits:
     memory: "128Mi"
@@ -14,5 +14,4 @@ kymaAddress: 35.195.198.66.xip.io
 
 githubToken: sampleToken
 githubEndpoint: 
-  - repo
-  - repo2
+  - repos/example/test

--- a/github-connector/cmd/github-connector/main.go
+++ b/github-connector/cmd/github-connector/main.go
@@ -19,6 +19,7 @@ import (
 type Config struct {
 	GithubConnectorName string `envconfig:"GITHUB_CONNECTOR_NAME"`
 	GithubToken         string `envconfig:"GITHUB_TOKEN"`
+	GithubSecret        string `envconfig:"GITHUB_SECRET"`
 	KymaAddress         string `envconfig:"KYMA_ADDRESS"`
 	Port                string `envconfig:"PORT"`
 }
@@ -49,8 +50,7 @@ func main() {
 	}).Info("Service registered")
 
 	webHook := hook.NewHook(conf.KymaAddress)
-	secret := webHook.GetSecret()
-	log.Infof("Webhook's secret: %s", secret)
+	secret := conf.GithubSecret
 	for i, address := range repos {
 		_, err := webHook.Create(conf.GithubToken, address, secret)
 		if err != nil {

--- a/github-connector/internal/hook/hook.go
+++ b/github-connector/internal/hook/hook.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"net/http"
-	"time"
 
 	"github.com/kyma-incubator/hack-showcase/github-connector/internal/apperrors"
 )
@@ -15,13 +13,11 @@ const (
 	kymaURLPrefix = "https://"
 	kymaURLSuffix = "/webhook"
 	kymaURLFormat = "%s%s%s"
-	charset       = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 )
 
 //Hook describe hook struct
 type Hook interface {
 	Create(t string, githubURL string, secret string) (string, apperrors.AppError)
-	GetSecret() string
 }
 
 //Hook is a struct that contains information about github's repo/org url, OAuth token and allows creating webhooks
@@ -33,11 +29,6 @@ type hook struct {
 func NewHook(URL string) Hook {
 	kURL := fmt.Sprintf(kymaURLFormat, kymaURLPrefix, URL, kymaURLSuffix)
 	return &hook{kymaURL: kURL}
-}
-
-//GetSecret creates new secret for creating Github's webhook
-func (s *hook) GetSecret() string {
-	return createSecret(charset)
 }
 
 //Create build request and create webhook in github's repository or organization
@@ -79,13 +70,4 @@ func (s *hook) Create(t string, githubURL string, secret string) (string, apperr
 		return "", apperrors.UpstreamServerCallFailed("Unpredicted response code: %v", httpResponse.StatusCode)
 	}
 	return secret, nil
-}
-
-func createSecret(charset string) string {
-	seed := rand.New(rand.NewSource(time.Now().UnixNano()))
-	secret := make([]byte, (rand.Intn(7) + 8))
-	for i := range secret {
-		secret[i] = charset[seed.Intn(len(charset))]
-	}
-	return string(secret)
 }

--- a/github-connector/internal/hook/hook_test.go
+++ b/github-connector/internal/hook/hook_test.go
@@ -46,14 +46,3 @@ func TestCreate(t *testing.T) {
 		assert.Equal(t, "", token)
 	})
 }
-
-func TestGetSecret(t *testing.T) {
-	t.Run("should return secret", func(t *testing.T) {
-		//given
-		webhook := hook.NewHook("URL")
-		//when
-		secret := webhook.GetSecret()
-		//then
-		assert.NotEmpty(t, secret)
-	})
-}


### PR DESCRIPTION
Secret is generated in deployment and passed as an environmental variable to program. User can get this secret with command:
```kubectl get deployments -n {NAMESPACE} {DEPLOYMENT_NAME} -o jsonpath='{.spec.template.spec.containers[0].env[3].value}'```
Deleted GetSecret function from hook package.